### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/327/09/85632709.geojson
+++ b/data/856/327/09/85632709.geojson
@@ -875,6 +875,10 @@
     },
     "wof:country":"KI",
     "wof:country_alpha3":"KIR",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"4b54449e0f7e1fa2d0c68af2e62d5085",
     "wof:hierarchy":[
         {
@@ -891,7 +895,7 @@
         "eng",
         "gil"
     ],
-    "wof:lastmodified":1566727654,
+    "wof:lastmodified":1582346026,
     "wof:name":"Kiribati",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/413/077/890413077.geojson
+++ b/data/890/413/077/890413077.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"KI",
     "wof:created":1469050987,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80f4ea71a8963f5ad195d80f1ba815ae",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890413077,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1582346027,
     "wof:name":"Buota Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/416/393/890416393.geojson
+++ b/data/890/416/393/890416393.geojson
@@ -389,6 +389,10 @@
     },
     "wof:country":"KI",
     "wof:created":1469051132,
+    "wof:geom_alt":[
+        "unknown",
+        "naturalearth"
+    ],
     "wof:geomhash":"0b7843a16b923c933ec66d2d242e2dc1",
     "wof:hierarchy":[
         {
@@ -397,7 +401,7 @@
         }
     ],
     "wof:id":890416393,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1582346027,
     "wof:name":"Tarawa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/285/890424285.geojson
+++ b/data/890/424/285/890424285.geojson
@@ -42,6 +42,9 @@
     },
     "wof:country":"KI",
     "wof:created":1469051538,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1f6edeeebde0376853ca92cb06ba9de",
     "wof:hierarchy":[
         {
@@ -52,7 +55,7 @@
         }
     ],
     "wof:id":890424285,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1582346027,
     "wof:name":"Bairiki Town",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.