### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/578/121/5/1125781215.geojson
+++ b/data/112/578/121/5/1125781215.geojson
@@ -22,7 +22,13 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:deu_x_preferred":[
+        "Tabukiniberu"
+    ],
     "name:eng_x_preferred":[
+        "Tabukiniberu"
+    ],
+    "name:fra_x_preferred":[
         "Tabukiniberu"
     ],
     "name:nld_x_preferred":[
@@ -67,7 +73,7 @@
         }
     ],
     "wof:id":1125781215,
-    "wof:lastmodified":1566727664,
+    "wof:lastmodified":1690938172,
     "wof:name":"Tabukiniberu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/587/123/9/1125871239.geojson
+++ b/data/112/587/123/9/1125871239.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Napia Village"
     ],
+    "name:deu_x_preferred":[
+        "Paelau"
+    ],
     "name:eng_x_preferred":[
         "Paelau"
     ],
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":1125871239,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938172,
     "wof:name":"Napia Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/587/124/7/1125871247.geojson
+++ b/data/112/587/124/7/1125871247.geojson
@@ -25,7 +25,13 @@
     "name:ceb_x_preferred":[
         "Napari Village"
     ],
+    "name:deu_x_preferred":[
+        "Napari"
+    ],
     "name:eng_x_preferred":[
+        "Napari"
+    ],
+    "name:fra_x_preferred":[
         "Napari"
     ],
     "name:nld_x_preferred":[
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":1125871247,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938172,
     "wof:name":"Napari Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/112/598/767/9/1125987679.geojson
+++ b/data/112/598/767/9/1125987679.geojson
@@ -28,7 +28,13 @@
     "name:ceb_x_preferred":[
         "Rungata"
     ],
+    "name:deu_x_preferred":[
+        "Rungata"
+    ],
     "name:eng_x_preferred":[
+        "Rungata"
+    ],
+    "name:fra_x_preferred":[
         "Rungata"
     ],
     "name:nld_x_preferred":[
@@ -36,6 +42,9 @@
     ],
     "name:pol_x_preferred":[
         "Rungata"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0443\u043d\u0433\u0430\u0442\u0430"
     ],
     "name:swe_x_preferred":[
         "Rungata"
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1125987679,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938172,
     "wof:name":"Rungata",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/201/685/421201685.geojson
+++ b/data/421/201/685/421201685.geojson
@@ -35,6 +35,9 @@
     "name:epo_x_preferred":[
         "Londono"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0646\u062f\u0646"
+    ],
     "name:fra_x_preferred":[
         "London"
     ],
@@ -65,10 +68,16 @@
     "name:lzh_x_preferred":[
         "\u502b\u6566"
     ],
+    "name:nan_x_preferred":[
+        "London"
+    ],
     "name:nld_x_preferred":[
         "London"
     ],
     "name:pol_x_preferred":[
+        "London"
+    ],
+    "name:por_x_preferred":[
         "London"
     ],
     "name:rus_x_preferred":[
@@ -127,7 +136,7 @@
         }
     ],
     "wof:id":421201685,
-    "wof:lastmodified":1636500709,
+    "wof:lastmodified":1690938142,
     "wof:name":"London",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/327/09/85632709.geojson
+++ b/data/856/327/09/85632709.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
     "name:ace_x_preferred":[
         "Kiribati"
     ],
@@ -46,8 +49,14 @@
     "name:amh_x_variant":[
         "\u12aa\u122a\u1263\u1272"
     ],
+    "name:ami_x_preferred":[
+        "Kiribati"
+    ],
     "name:ang_x_preferred":[
         "Kiribas"
+    ],
+    "name:anp_x_preferred":[
+        "\u0915\u0940\u0930\u0940\u092c\u093e\u0924\u0940"
     ],
     "name:ara_x_preferred":[
         "\u0643\u064a\u0631\u064a\u0628\u0627\u062a\u064a"
@@ -58,11 +67,17 @@
     "name:arg_x_preferred":[
         "Kiribati"
     ],
+    "name:ary_x_preferred":[
+        "\u0643\u064a\u0631\u064a\u0628\u0627\u062a\u064a"
+    ],
     "name:arz_x_preferred":[
         "\u0643\u064a\u0631\u064a\u0628\u0627\u062a\u0649"
     ],
     "name:ast_x_preferred":[
         "Kiribati"
+    ],
+    "name:avk_x_preferred":[
+        "Kiribatia"
     ],
     "name:azb_x_preferred":[
         "\u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc"
@@ -74,6 +89,9 @@
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
     ],
     "name:bam_x_preferred":[
+        "Kiribati"
+    ],
+    "name:ban_x_preferred":[
         "Kiribati"
     ],
     "name:bcl_x_preferred":[
@@ -90,6 +108,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0915\u093f\u0930\u093f\u092c\u093e\u0924\u0940"
+    ],
+    "name:bis_x_preferred":[
+        "Kiribati"
     ],
     "name:bjn_x_preferred":[
         "Kiribati"
@@ -133,16 +154,25 @@
     "name:che_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
     ],
+    "name:chr_x_preferred":[
+        "\u13a7\u13b5\u13c6\u13d8"
+    ],
     "name:chu_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
     ],
     "name:chv_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
     ],
+    "name:chy_x_preferred":[
+        "Kiribati"
+    ],
     "name:ckb_x_preferred":[
         "\u06a9\u06cc\u0631\u06cc\u0628\u0627\u0633"
     ],
     "name:cor_x_preferred":[
+        "Kiribati"
+    ],
+    "name:cos_x_preferred":[
         "Kiribati"
     ],
     "name:crh_x_preferred":[
@@ -152,6 +182,9 @@
         "Ciribati"
     ],
     "name:cym_x_variant":[
+        "Kiribati"
+    ],
+    "name:dag_x_preferred":[
         "Kiribati"
     ],
     "name:dan_x_preferred":[
@@ -220,13 +253,22 @@
     "name:frp_x_preferred":[
         "Kiribati"
     ],
+    "name:frr_x_preferred":[
+        "Kiribaati"
+    ],
     "name:fry_x_preferred":[
         "Kiribaty"
     ],
     "name:ful_x_preferred":[
         "Kiribari"
     ],
+    "name:ful_x_variant":[
+        "Kiribaati"
+    ],
     "name:gag_x_preferred":[
+        "Kiribati"
+    ],
+    "name:gcr_x_preferred":[
         "Kiribati"
     ],
     "name:ger_x_variant":[
@@ -256,6 +298,9 @@
     "name:gom_x_preferred":[
         "\u0915\u093f\u0930\u093f\u092c\u093e\u091f\u0940"
     ],
+    "name:gpe_x_preferred":[
+        "Kiribati"
+    ],
     "name:grn_x_preferred":[
         "Kiriv\u00e1ti"
     ],
@@ -276,6 +321,9 @@
     ],
     "name:hau_x_preferred":[
         "Kiribati"
+    ],
+    "name:haw_x_preferred":[
+        "Kilipaki"
     ],
     "name:hbs_x_preferred":[
         "Kiribati"
@@ -403,6 +451,9 @@
     "name:lit_x_preferred":[
         "Kiribatis"
     ],
+    "name:lld_x_preferred":[
+        "Kiribati"
+    ],
     "name:lmo_x_preferred":[
         "Kiribati"
     ],
@@ -430,6 +481,12 @@
     "name:mar_x_variant":[
         "\u0915\u093f\u0930\u0940\u092c\u093e\u091f\u0940"
     ],
+    "name:mhr_x_preferred":[
+        "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
+    "name:min_x_preferred":[
+        "Kiribati"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
     ],
@@ -442,8 +499,14 @@
     "name:mlt_x_preferred":[
         "Kiribati"
     ],
+    "name:mni_x_preferred":[
+        "\uabc0\uabe4\uabd4\uabe4\uabd5\uabc7\uabe4"
+    ],
     "name:mon_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
+    "name:mri_x_preferred":[
+        "Kirip\u0101ti"
     ],
     "name:mrj_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
@@ -575,6 +638,9 @@
     "name:sgs_x_preferred":[
         "K\u0117r\u0117batis"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1075\u102d\u101b\u102d\u1015\u1010\u102e\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dd2\u0dbb\u0dd2\u0db6\u0da7\u0dd2"
     ],
@@ -587,14 +653,23 @@
     "name:sme_x_preferred":[
         "Kiribati"
     ],
+    "name:smn_x_preferred":[
+        "Kiribati"
+    ],
     "name:smo_x_preferred":[
         "Kiripati"
     ],
     "name:smo_x_variant":[
         "Kilibati"
     ],
+    "name:sms_x_preferred":[
+        "Kiribaat"
+    ],
     "name:sna_x_preferred":[
         "Kiribati"
+    ],
+    "name:snd_x_preferred":[
+        "\u06aa\u0631\u064a\u0628\u062a\u064a"
     ],
     "name:som_x_preferred":[
         "Kiribati"
@@ -607,6 +682,9 @@
     ],
     "name:sqi_x_variant":[
         "Qiribati"
+    ],
+    "name:srd_x_preferred":[
+        "Kiribati"
     ],
     "name:srp_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
@@ -658,6 +736,9 @@
     "name:tir_x_preferred":[
         "\u12aa\u122a\u1263\u1272"
     ],
+    "name:tok_x_preferred":[
+        "ma Kilipasi"
+    ],
     "name:ton_x_preferred":[
         "Kilipasi"
     ],
@@ -669,6 +750,9 @@
     ],
     "name:tur_x_preferred":[
         "Kiribati"
+    ],
+    "name:udm_x_preferred":[
+        "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
     ],
     "name:uig_x_preferred":[
         "\u0643\u0649\u0631\u0649\u0628\u0627\u062a\u0649"
@@ -691,6 +775,9 @@
     "name:uzb_x_preferred":[
         "Kiribati"
     ],
+    "name:vec_x_preferred":[
+        "Kiribati"
+    ],
     "name:vep_x_preferred":[
         "Kiribati"
     ],
@@ -711,6 +798,9 @@
     ],
     "name:wol_x_preferred":[
         "Kiribati"
+    ],
+    "name:wuu_x_preferred":[
+        "\u57fa\u91cc\u5df4\u65af"
     ],
     "name:xal_x_preferred":[
         "\u041a\u0438\u0440\u0438\u0431\u0430\u0434\u0438\u043d \u041e\u0440\u043d"
@@ -970,7 +1060,7 @@
         "eng",
         "gil"
     ],
-    "wof:lastmodified":1636500709,
+    "wof:lastmodified":1690938142,
     "wof:name":"Kiribati",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/413/017/890413017.geojson
+++ b/data/890/413/017/890413017.geojson
@@ -22,8 +22,17 @@
     "name:eng_x_preferred":[
         "Bah\u00e1'\u00ed Faith in Kiribati"
     ],
+    "name:ita_x_preferred":[
+        "Bahai nelle Kiribati"
+    ],
+    "name:rus_x_preferred":[
+        "\u0431\u0430\u0445\u0430\u0438 \u0432 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
     "name:spa_x_preferred":[
         "Baha\u00edsmo en Kiribati"
+    ],
+    "name:spa_x_variant":[
+        "Fe bah\u00e1'\u00ed en Kiribati"
     ],
     "qs:name":"Tewai Village",
     "qs:photos_9r":0,
@@ -52,7 +61,7 @@
         }
     ],
     "wof:id":890413017,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938148,
     "wof:name":"Tewai Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/019/890413019.geojson
+++ b/data/890/413/019/890413019.geojson
@@ -19,7 +19,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Teteirio"
+    ],
     "name:eng_x_preferred":[
+        "Teteirio"
+    ],
+    "name:fra_x_preferred":[
         "Teteirio"
     ],
     "name:nld_x_preferred":[
@@ -50,7 +56,7 @@
         }
     ],
     "wof:id":890413019,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938148,
     "wof:name":"Teteirio Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/025/890413025.geojson
+++ b/data/890/413/025/890413025.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0431\u0430\u0438\u0430\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Abaiang"
+    ],
     "name:ceb_x_preferred":[
         "Abaiang"
     ],
@@ -79,6 +82,9 @@
     "name:nld_x_preferred":[
         "Abaiang"
     ],
+    "name:pol_x_preferred":[
+        "Abaiang"
+    ],
     "name:por_x_preferred":[
         "Abaiang"
     ],
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":890413025,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938145,
     "wof:name":"Tebunginako Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/413/031/890413031.geojson
+++ b/data/890/413/031/890413031.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -94,6 +97,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Tebanga Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -125,7 +131,7 @@
         }
     ],
     "wof:id":890413031,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938145,
     "wof:name":"Tebanga Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/413/033/890413033.geojson
+++ b/data/890/413/033/890413033.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -94,6 +97,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Tebanga Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":890413033,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938149,
     "wof:name":"Tebanga Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/037/890413037.geojson
+++ b/data/890/413/037/890413037.geojson
@@ -25,17 +25,32 @@
     "name:eng_x_preferred":[
         "Demographics of Kiribati"
     ],
+    "name:eng_x_variant":[
+        "demographics of Kiribati"
+    ],
     "name:fin_x_preferred":[
         "Kiribatin v\u00e4est\u00f6"
     ],
     "name:fra_x_preferred":[
         "D\u00e9mographie des Kiribati"
     ],
+    "name:fra_x_variant":[
+        "d\u00e9mographie des Kiribati"
+    ],
     "name:heb_x_preferred":[
         "\u05d3\u05de\u05d5\u05d2\u05e8\u05e4\u05d9\u05d4 \u05e9\u05dc \u05e7\u05d9\u05e8\u05d9\u05d1\u05d8\u05d9"
     ],
     "name:hrv_x_preferred":[
         "Stanovni\u0161tvo Kiribatija"
+    ],
+    "name:kor_x_preferred":[
+        "\ud0a4\ub9ac\ubc14\uc2dc\uc758 \uc778\uad6c"
+    ],
+    "name:nld_x_preferred":[
+        "demografie van Kiribati"
+    ],
+    "name:nob_x_preferred":[
+        "Kiribatis befolkning"
     ],
     "name:rus_x_preferred":[
         "\u043d\u0430\u0441\u0435\u043b\u0435\u043d\u0438\u0435 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
@@ -76,7 +91,7 @@
         }
     ],
     "wof:id":890413037,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938146,
     "wof:name":"Teaoraereke Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/043/890413043.geojson
+++ b/data/890/413/043/890413043.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Tabontebike Village"
     ],
+    "name:deu_x_preferred":[
+        "Tabontebike"
+    ],
     "name:eng_x_preferred":[
+        "Tabontebike"
+    ],
+    "name:fra_x_preferred":[
         "Tabontebike"
     ],
     "name:nld_x_preferred":[
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":890413043,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938148,
     "wof:name":"Tabontebike Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/045/890413045.geojson
+++ b/data/890/413/045/890413045.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -32,6 +41,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":890413045,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938147,
     "wof:name":"Tanimaiaki Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/051/890413051.geojson
+++ b/data/890/413/051/890413051.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Rongorongo text Z"
     ],
+    "name:eng_x_variant":[
+        "Rongorongo text"
+    ],
     "name:jpn_x_preferred":[
         "\u30dd\u30a4\u30b1 \u91cd\u306d\u66f8\u304d\u6587\u5b57\u677f(Poike palimpsest)"
     ],
@@ -56,7 +59,7 @@
         }
     ],
     "wof:id":890413051,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938149,
     "wof:name":"Rongorongo Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/413/055/890413055.geojson
+++ b/data/890/413/055/890413055.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0646\u0627\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0646\u0627\u0628\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0411\u0430\u043d\u0430\u0431\u0430"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:ces_x_preferred":[
         "Banaba"
+    ],
+    "name:che_x_preferred":[
+        "\u041e\u0448\u0435\u043d"
     ],
     "name:dan_x_preferred":[
         "Banaba"
@@ -55,6 +61,9 @@
     "name:est_x_preferred":[
         "Banaba"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0646\u0627\u0628\u0627"
+    ],
     "name:fin_x_preferred":[
         "Banaba"
     ],
@@ -68,6 +77,12 @@
         "\u05d1\u05e0\u05d1\u05d4"
     ],
     "name:hrv_x_preferred":[
+        "Banaba"
+    ],
+    "name:ind_x_preferred":[
+        "Pulau Banaba"
+    ],
+    "name:isl_x_preferred":[
         "Banaba"
     ],
     "name:ita_x_preferred":[
@@ -117,6 +132,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0411\u0430\u043d\u0430\u0431\u0430"
+    ],
+    "name:slk_x_preferred":[
+        "Banaba"
     ],
     "name:spa_x_preferred":[
         "Banaba"
@@ -172,7 +190,7 @@
         }
     ],
     "wof:id":890413055,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938146,
     "wof:name":"Tabewa Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/057/890413057.geojson
+++ b/data/890/413/057/890413057.geojson
@@ -22,14 +22,35 @@
     "name:ast_x_preferred":[
         "Encierru"
     ],
+    "name:cat_x_preferred":[
+        "ocupaci\u00f3"
+    ],
     "name:deu_x_preferred":[
         "Bestzung"
+    ],
+    "name:deu_x_variant":[
+        "Besetzung"
+    ],
+    "name:ell_x_preferred":[
+        "\u03ba\u03b1\u03c4\u03ac\u03bb\u03b7\u03c8\u03b7"
     ],
     "name:eng_x_preferred":[
         "occupation"
     ],
     "name:eus_x_preferred":[
         "Itxialdi"
+    ],
+    "name:fin_x_preferred":[
+        "valtaus"
+    ],
+    "name:fra_x_preferred":[
+        "occupation"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d0\u05ea \u05db\u05d9\u05d1\u05d5\u05e9"
+    ],
+    "name:hun_x_preferred":[
+        "elfoglal\u00e1s"
     ],
     "name:ita_x_preferred":[
         "occupazione"
@@ -43,8 +64,14 @@
     "name:rus_x_preferred":[
         "\u0417\u0430\u0445\u0432\u0430\u0442 \u0437\u0434\u0430\u043d\u0438\u044f"
     ],
+    "name:slv_x_preferred":[
+        "zasedba"
+    ],
     "name:spa_x_preferred":[
         "encierro voluntario"
+    ],
+    "name:swe_x_preferred":[
+        "ockupation"
     ],
     "name:ukr_x_preferred":[
         "\u0437\u0430\u0445\u043e\u043f\u043b\u0435\u043d\u043d\u044f"
@@ -89,7 +116,7 @@
         }
     ],
     "wof:id":890413057,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938149,
     "wof:name":"Umwa Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/413/059/890413059.geojson
+++ b/data/890/413/059/890413059.geojson
@@ -22,8 +22,17 @@
     "name:eng_x_preferred":[
         "Bah\u00e1'\u00ed Faith in Kiribati"
     ],
+    "name:ita_x_preferred":[
+        "Bahai nelle Kiribati"
+    ],
+    "name:rus_x_preferred":[
+        "\u0431\u0430\u0445\u0430\u0438 \u0432 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
     "name:spa_x_preferred":[
         "Baha\u00edsmo en Kiribati"
+    ],
+    "name:spa_x_variant":[
+        "Fe bah\u00e1'\u00ed en Kiribati"
     ],
     "qs:name":"Tekabwibwi Village",
     "qs:photos_9r":0,
@@ -52,7 +61,7 @@
         }
     ],
     "wof:id":890413059,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938149,
     "wof:name":"Tekabwibwi Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/069/890413069.geojson
+++ b/data/890/413/069/890413069.geojson
@@ -28,6 +28,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -35,6 +38,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -135,7 +144,7 @@
         }
     ],
     "wof:id":890413069,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938149,
     "wof:name":"Kariatebike Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/073/890413073.geojson
+++ b/data/890/413/073/890413073.geojson
@@ -31,6 +31,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -38,6 +41,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -69,6 +75,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -143,7 +152,7 @@
         }
     ],
     "wof:id":890413073,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938147,
     "wof:name":"Kabangaki Village",
     "wof:parent_id":85681281,
     "wof:placetype":"locality",

--- a/data/890/413/087/890413087.geojson
+++ b/data/890/413/087/890413087.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Borotiam Village"
     ],
+    "name:deu_x_preferred":[
+        "Borotiam"
+    ],
     "name:eng_x_preferred":[
+        "Borotiam"
+    ],
+    "name:fra_x_preferred":[
         "Borotiam"
     ],
     "name:nld_x_preferred":[
@@ -65,7 +71,7 @@
         }
     ],
     "wof:id":890413087,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938147,
     "wof:name":"Borotiam Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/413/091/890413091.geojson
+++ b/data/890/413/091/890413091.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -280,7 +310,7 @@
         }
     ],
     "wof:id":890413091,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938145,
     "wof:name":"Betio Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/093/890413093.geojson
+++ b/data/890/413/093/890413093.geojson
@@ -31,7 +31,13 @@
     "name:eng_x_preferred":[
         "Beru Island"
     ],
+    "name:eng_x_variant":[
+        "Beru"
+    ],
     "name:est_x_preferred":[
+        "Beru"
+    ],
+    "name:fao_x_preferred":[
         "Beru"
     ],
     "name:fas_x_preferred":[
@@ -45,6 +51,9 @@
     ],
     "name:glg_x_preferred":[
         "Atol Beru"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d8\u05d5\u05dc \u05d1\u05e8\u05d5"
     ],
     "name:hrv_x_preferred":[
         "Beru"
@@ -66,6 +75,9 @@
     ],
     "name:nld_x_preferred":[
         "Beru Island"
+    ],
+    "name:pol_x_preferred":[
+        "Beru"
     ],
     "name:por_x_preferred":[
         "Beru"
@@ -118,7 +130,7 @@
         }
     ],
     "wof:id":890413093,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938150,
     "wof:name":"Beru Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/095/890413095.geojson
+++ b/data/890/413/095/890413095.geojson
@@ -22,6 +22,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0643\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0438"
     ],
@@ -35,6 +38,9 @@
         "\u039c\u03b1\u03c1\u03b1\u03ba\u03ad\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Marakei"
+    ],
+    "name:est_x_preferred":[
         "Marakei"
     ],
     "name:fas_x_preferred":[
@@ -73,6 +79,9 @@
     "name:nld_x_preferred":[
         "Marakei"
     ],
+    "name:pol_x_preferred":[
+        "Marakei"
+    ],
     "name:por_x_preferred":[
         "Marakei"
     ],
@@ -87,6 +96,9 @@
     ],
     "name:tur_x_preferred":[
         "Marakei"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0440\u0430\u043a\u0435\u0457"
     ],
     "name:und_x_variant":[
         "Baretoa"
@@ -121,7 +133,7 @@
         }
     ],
     "wof:id":890413095,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938148,
     "wof:name":"Baretoa Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/097/890413097.geojson
+++ b/data/890/413/097/890413097.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -249,6 +273,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -287,7 +317,7 @@
         }
     ],
     "wof:id":890413097,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938146,
     "wof:name":"Banraeaba Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/413/105/890413105.geojson
+++ b/data/890/413/105/890413105.geojson
@@ -19,10 +19,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Aonobuaka"
+    ],
     "name:eng_x_preferred":[
         "Aonobuaka"
     ],
     "name:nld_x_preferred":[
+        "Aonobuaka"
+    ],
+    "name:pol_x_preferred":[
         "Aonobuaka"
     ],
     "name:und_x_variant":[
@@ -55,7 +61,7 @@
         }
     ],
     "wof:id":890413105,
-    "wof:lastmodified":1566727656,
+    "wof:lastmodified":1690938144,
     "wof:name":"Aonobuaka Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/416/393/890416393.geojson
+++ b/data/890/416/393/890416393.geojson
@@ -33,11 +33,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -108,6 +117,9 @@
     ],
     "name:gla_x_preferred":[
         "South Tarawa"
+    ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
     ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
@@ -200,6 +212,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -233,6 +248,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -247,6 +265,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -271,6 +292,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -409,7 +436,7 @@
         }
     ],
     "wof:id":890416393,
-    "wof:lastmodified":1636500710,
+    "wof:lastmodified":1690938162,
     "wof:name":"Tarawa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/571/890418571.geojson
+++ b/data/890/418/571/890418571.geojson
@@ -21,11 +21,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u062a\u0627\u0631\u064a\u062a\u0627\u0631\u064a"
     ],
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09c1\u09a4\u09be\u09b0\u09bf\u09a4\u09be\u09b0\u09bf"
     ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -37,6 +46,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -140,7 +155,7 @@
         }
     ],
     "wof:id":890418571,
-    "wof:lastmodified":1636500710,
+    "wof:lastmodified":1690938166,
     "wof:name":"Butaritari",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/577/890418577.geojson
+++ b/data/890/418/577/890418577.geojson
@@ -24,6 +24,12 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u0631\u064a\u062a\u064a\u0645\u0627\u0633"
     ],
+    "name:ara_x_variant":[
+        "\u0643\u064a\u0631\u064a\u062a\u064a\u0645\u0627\u062a\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0631\u064a\u062a\u064a\u0645\u0627\u0633"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u041a\u0456\u0440\u044b\u0446\u0456\u043c\u0430\u0446\u0456"
     ],
@@ -32,6 +38,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0915\u094d\u0930\u093f\u0938\u092e\u0938 \u0926\u0940\u092a"
+    ],
+    "name:bho_x_variant":[
+        "\u0915\u093f\u0930\u093f\u0924\u093f\u092e\u093e\u0924\u0940"
     ],
     "name:bre_x_preferred":[
         "Kiritimati"
@@ -114,6 +123,9 @@
     "name:kor_x_preferred":[
         "\ud0a4\ub9ac\ud2f0\ub9c8\ud2f0\uc12c"
     ],
+    "name:kor_x_variant":[
+        "\ud0a4\ub9ac\ud2f0\ub9c8\ud2f0"
+    ],
     "name:lav_x_preferred":[
         "Kirisimasi"
     ],
@@ -180,8 +192,17 @@
     "name:urd_x_preferred":[
         "\u06a9\u06cc\u0631\u06cc\u0679\u06cc\u0645\u0627\u062a\u06cc"
     ],
+    "name:urd_x_variant":[
+        "\u06a9\u06cc\u0631\u06cc\u062a\u06cc\u0645\u0627\u062a\u06cc"
+    ],
+    "name:uzb_x_preferred":[
+        "Rojdestvo oroli"
+    ],
     "name:vie_x_preferred":[
         "Kiritimati"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5723\u8bde\u5c9b"
     ],
     "name:xmf_x_preferred":[
         "\u10e5\u10d8\u10e0\u10e1\u10d4\u10e8 \u10d9\u10dd\u10d9\u10d8"
@@ -218,7 +239,7 @@
         }
     ],
     "wof:id":890418577,
-    "wof:lastmodified":1636500711,
+    "wof:lastmodified":1690938166,
     "wof:name":"Kiritimati",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/581/890418581.geojson
+++ b/data/890/418/581/890418581.geojson
@@ -36,6 +36,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -90,6 +93,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Maiana",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":890418581,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938164,
     "wof:name":"Maiana",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/585/890418585.geojson
+++ b/data/890/418/585/890418585.geojson
@@ -34,6 +34,9 @@
     "name:epo_x_preferred":[
         "Kuria"
     ],
+    "name:est_x_preferred":[
+        "Kuria"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u06cc\u0627"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890418585,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938166,
     "wof:name":"Manenaua Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/587/890418587.geojson
+++ b/data/890/418/587/890418587.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Tabontebike Village"
     ],
+    "name:deu_x_preferred":[
+        "Tabontebike"
+    ],
     "name:eng_x_preferred":[
+        "Tabontebike"
+    ],
+    "name:fra_x_preferred":[
         "Tabontebike"
     ],
     "name:nld_x_preferred":[
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":890418587,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938164,
     "wof:name":"Tabontebike Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/593/890418593.geojson
+++ b/data/890/418/593/890418593.geojson
@@ -34,6 +34,9 @@
     "name:epo_x_preferred":[
         "Kuria"
     ],
+    "name:est_x_preferred":[
+        "Kuria"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u06cc\u0627"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890418593,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938163,
     "wof:name":"Bouatoa Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/597/890418597.geojson
+++ b/data/890/418/597/890418597.geojson
@@ -28,6 +28,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -35,6 +38,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -132,7 +141,7 @@
         }
     ],
     "wof:id":890418597,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938165,
     "wof:name":"Bangotantekabaia Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/599/890418599.geojson
+++ b/data/890/418/599/890418599.geojson
@@ -25,6 +25,9 @@
     "name:fra_x_preferred":[
         "Giriama"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ae\u30ea\u30a2\u30de"
+    ],
     "name:rus_x_preferred":[
         "\u0413\u0438\u0440\u044c\u044f\u043c\u0430"
     ],
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":890418599,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938164,
     "wof:name":"Kauma Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/601/890418601.geojson
+++ b/data/890/418/601/890418601.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Tekaranga Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890418601,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938165,
     "wof:name":"Tekaranga Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/603/890418603.geojson
+++ b/data/890/418/603/890418603.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Tematantongo Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890418603,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938164,
     "wof:name":"Tematantongo Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/605/890418605.geojson
+++ b/data/890/418/605/890418605.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Bubutei Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890418605,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938163,
     "wof:name":"Bubutei Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/607/890418607.geojson
+++ b/data/890/418/607/890418607.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Raweai Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890418607,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938165,
     "wof:name":"Raweai Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/611/890418611.geojson
+++ b/data/890/418/611/890418611.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Aobike Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890418611,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938163,
     "wof:name":"Aobike Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/613/890418613.geojson
+++ b/data/890/418/613/890418613.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Teitai Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890418613,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938165,
     "wof:name":"Teitai Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/418/617/890418617.geojson
+++ b/data/890/418/617/890418617.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -284,7 +314,7 @@
         }
     ],
     "wof:id":890418617,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938163,
     "wof:name":"Antebuka Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/422/427/890422427.geojson
+++ b/data/890/422/427/890422427.geojson
@@ -28,6 +28,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -35,6 +38,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -132,7 +141,7 @@
         }
     ],
     "wof:id":890422427,
-    "wof:lastmodified":1566727655,
+    "wof:lastmodified":1690938143,
     "wof:name":"Manoku Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/429/890422429.geojson
+++ b/data/890/422/429/890422429.geojson
@@ -34,6 +34,9 @@
     "name:epo_x_preferred":[
         "Kuria"
     ],
+    "name:est_x_preferred":[
+        "Kuria"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u06cc\u0627"
     ],
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":890422429,
-    "wof:lastmodified":1566727655,
+    "wof:lastmodified":1690938143,
     "wof:name":"Kuria Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/422/433/890422433.geojson
+++ b/data/890/422/433/890422433.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0431\u0430\u0438\u0430\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Abaiang"
+    ],
     "name:ceb_x_preferred":[
         "Abaiang"
     ],
@@ -79,6 +82,9 @@
     "name:nld_x_preferred":[
         "Abaiang"
     ],
+    "name:pol_x_preferred":[
+        "Abaiang"
+    ],
     "name:por_x_preferred":[
         "Abaiang"
     ],
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":890422433,
-    "wof:lastmodified":1566727655,
+    "wof:lastmodified":1690938144,
     "wof:name":"Koinawa Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/422/435/890422435.geojson
+++ b/data/890/422/435/890422435.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -32,6 +41,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -121,7 +136,7 @@
         }
     ],
     "wof:id":890422435,
-    "wof:lastmodified":1566727655,
+    "wof:lastmodified":1690938144,
     "wof:name":"Keuea Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/437/890422437.geojson
+++ b/data/890/422/437/890422437.geojson
@@ -19,16 +19,34 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062f\u0631\u0627\u063a\u0648\u0646 \u0628\u0648\u0644 \u0625\u0641\u0648\u0644\u0648\u0634\u064a\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u062f\u0631\u0627\u062c\u0648\u0646 \u0628\u0648\u0644 \u0627\u0641\u0648\u0644\u0648\u0634\u064a\u0646"
+    ],
     "name:ast_x_preferred":[
         "Dragonball Evolution"
     ],
     "name:ben_x_preferred":[
         "\u09a1\u09cd\u09b0\u09cd\u09af\u09be\u0997\u09a8\u09ac\u09b2 \u0987\u09ad\u09cb\u09b2\u09cd\u09af\u09c1\u09b6\u09a8"
     ],
+    "name:cat_x_preferred":[
+        "Dragonball Evolution"
+    ],
+    "name:ceb_x_preferred":[
+        "Dragonball Evolution"
+    ],
+    "name:cym_x_preferred":[
+        "Esblygiad Dragonball"
+    ],
     "name:dan_x_preferred":[
         "Dragonball: Evolution"
     ],
     "name:deu_x_preferred":[
+        "Dragonball Evolution"
+    ],
+    "name:ell_x_preferred":[
         "Dragonball Evolution"
     ],
     "name:eng_x_preferred":[
@@ -82,6 +100,9 @@
     "name:ron_x_preferred":[
         "Dragonball: Evolu\u021bie"
     ],
+    "name:ron_x_variant":[
+        "Dragonball: Evolu\u021bia"
+    ],
     "name:rus_x_preferred":[
         "\u0414\u0440\u0430\u043a\u043e\u043d\u0438\u0439 \u0436\u0435\u043c\u0447\u0443\u0433: \u042d\u0432\u043e\u043b\u044e\u0446\u0438\u044f"
     ],
@@ -96,6 +117,12 @@
     ],
     "name:tha_x_preferred":[
         "\u0e14\u0e23\u0e32\u0e01\u0e49\u0e2d\u0e19\u0e1a\u0e2d\u0e25 \u0e2d\u0e35\u0e42\u0e27\u0e25\u0e39\u0e0a\u0e31\u0e48\u0e19 \u0e40\u0e1b\u0e34\u0e14\u0e15\u0e33\u0e19\u0e32\u0e19\u0e43\u0e2b\u0e21\u0e48 \u0e19\u0e31\u0e01\u0e2a\u0e39\u0e49\u0e01\u0e39\u0e49\u0e42\u0e25\u0e01"
+    ],
+    "name:tur_x_preferred":[
+        "Ejder Topu: Evrim"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041f\u0435\u0440\u043b\u0438\u043d\u0438 \u0434\u0440\u0430\u043a\u043e\u043d\u0430: \u0415\u0432\u043e\u043b\u044e\u0446\u0456\u044f"
     ],
     "name:vie_x_preferred":[
         "Dragonball Evolution"
@@ -133,7 +160,7 @@
         }
     ],
     "wof:id":890422437,
-    "wof:lastmodified":1566727655,
+    "wof:lastmodified":1690938143,
     "wof:name":"Eriko Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/829/890422829.geojson
+++ b/data/890/422/829/890422829.geojson
@@ -22,8 +22,17 @@
     "name:eng_x_preferred":[
         "Bah\u00e1'\u00ed Faith in Kiribati"
     ],
+    "name:ita_x_preferred":[
+        "Bahai nelle Kiribati"
+    ],
+    "name:rus_x_preferred":[
+        "\u0431\u0430\u0445\u0430\u0438 \u0432 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
     "name:spa_x_preferred":[
         "Baha\u00edsmo en Kiribati"
+    ],
+    "name:spa_x_variant":[
+        "Fe bah\u00e1'\u00ed en Kiribati"
     ],
     "qs:name":"Ubanteman Village",
     "qs:photos_9r":0,
@@ -52,7 +61,7 @@
         }
     ],
     "wof:id":890422829,
-    "wof:lastmodified":1566727655,
+    "wof:lastmodified":1690938143,
     "wof:name":"Ubanteman Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/251/890424251.geojson
+++ b/data/890/424/251/890424251.geojson
@@ -21,6 +21,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0431\u0430\u0438\u0430\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Abaiang"
+    ],
     "name:ceb_x_preferred":[
         "Abaiang"
     ],
@@ -78,6 +81,9 @@
     "name:nld_x_preferred":[
         "Abaiang"
     ],
+    "name:pol_x_preferred":[
+        "Abaiang"
+    ],
     "name:por_x_preferred":[
         "Abaiang"
     ],
@@ -128,7 +134,7 @@
         }
     ],
     "wof:id":890424251,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938152,
     "wof:name":"Abaiang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/253/890424253.geojson
+++ b/data/890/424/253/890424253.geojson
@@ -27,6 +27,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -34,6 +37,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -65,6 +71,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -131,7 +140,7 @@
         }
     ],
     "wof:id":890424253,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938153,
     "wof:name":"Abemama",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/255/890424255.geojson
+++ b/data/890/424/255/890424255.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0631\u0627\u0646\u0648\u0643\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0631\u0627\u0646\u0648\u0643\u0627"
+    ],
     "name:aze_x_preferred":[
         "Aranuka adas\u0131"
     ],
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890424255,
-    "wof:lastmodified":1636500710,
+    "wof:lastmodified":1690938154,
     "wof:name":"Aranuka",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/269/890424269.geojson
+++ b/data/890/424/269/890424269.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Onotoa"
     ],
+    "name:ces_x_preferred":[
+        "Onotoa"
+    ],
     "name:deu_x_preferred":[
         "Onotoa"
     ],
@@ -32,6 +35,12 @@
         "\u039f\u03bd\u03bf\u03c4\u03cc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Onotoa"
+    ],
+    "name:est_x_preferred":[
+        "Onotoa"
+    ],
+    "name:fao_x_preferred":[
         "Onotoa"
     ],
     "name:fas_x_preferred":[
@@ -121,7 +130,7 @@
         }
     ],
     "wof:id":890424269,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938153,
     "wof:name":"Tekawa Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/271/890424271.geojson
+++ b/data/890/424/271/890424271.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Onotoa"
     ],
+    "name:ces_x_preferred":[
+        "Onotoa"
+    ],
     "name:deu_x_preferred":[
         "Onotoa"
     ],
@@ -32,6 +35,12 @@
         "\u039f\u03bd\u03bf\u03c4\u03cc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Onotoa"
+    ],
+    "name:est_x_preferred":[
+        "Onotoa"
+    ],
+    "name:fao_x_preferred":[
         "Onotoa"
     ],
     "name:fas_x_preferred":[
@@ -121,7 +130,7 @@
         }
     ],
     "wof:id":890424271,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938153,
     "wof:name":"Temao Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/277/890424277.geojson
+++ b/data/890/424/277/890424277.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Onotoa"
     ],
+    "name:ces_x_preferred":[
+        "Onotoa"
+    ],
     "name:deu_x_preferred":[
         "Onotoa"
     ],
@@ -32,6 +35,12 @@
         "\u039f\u03bd\u03bf\u03c4\u03cc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Onotoa"
+    ],
+    "name:est_x_preferred":[
+        "Onotoa"
+    ],
+    "name:fao_x_preferred":[
         "Onotoa"
     ],
     "name:fas_x_preferred":[
@@ -121,7 +130,7 @@
         }
     ],
     "wof:id":890424277,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938153,
     "wof:name":"Otowae Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/281/890424281.geojson
+++ b/data/890/424/281/890424281.geojson
@@ -34,6 +34,9 @@
     "name:epo_x_preferred":[
         "Kuria"
     ],
+    "name:est_x_preferred":[
+        "Kuria"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u06cc\u0627"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890424281,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938151,
     "wof:name":"Oneeke Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/287/890424287.geojson
+++ b/data/890/424/287/890424287.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -280,7 +310,7 @@
         }
     ],
     "wof:id":890424287,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938151,
     "wof:name":"Bairiki Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/289/890424289.geojson
+++ b/data/890/424/289/890424289.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -280,7 +310,7 @@
         }
     ],
     "wof:id":890424289,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938151,
     "wof:name":"Nanikai Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/293/890424293.geojson
+++ b/data/890/424/293/890424293.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -284,7 +314,7 @@
         }
     ],
     "wof:id":890424293,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938152,
     "wof:name":"Taborio Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/424/295/890424295.geojson
+++ b/data/890/424/295/890424295.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -280,7 +310,7 @@
         }
     ],
     "wof:id":890424295,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938152,
     "wof:name":"Bonriki Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/301/890424301.geojson
+++ b/data/890/424/301/890424301.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -249,6 +273,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -287,7 +317,7 @@
         }
     ],
     "wof:id":890424301,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938150,
     "wof:name":"Nawerewere Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/424/303/890424303.geojson
+++ b/data/890/424/303/890424303.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0456\u043a\u0435\u043d\u0456\u0431\u044c\u044e"
+    ],
+    "name:ceb_x_preferred":[
+        "Bikenibeu Village"
+    ],
     "name:deu_x_preferred":[
         "Bikenibeu"
     ],
@@ -31,6 +37,12 @@
     "name:fra_x_preferred":[
         "Bikenibeu"
     ],
+    "name:ita_x_preferred":[
+        "Bikenibeu"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d3\u30b1\u30cb\u30d9\u30a6\u5cf6"
+    ],
     "name:nld_x_preferred":[
         "Bikenibeu"
     ],
@@ -40,8 +52,14 @@
     "name:por_x_preferred":[
         "Bikenibeu"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0438\u043a\u0435\u043d\u0438\u0431\u0435\u0443"
+    ],
     "name:spa_x_preferred":[
         "Bikenibeu"
+    ],
+    "name:swe_x_preferred":[
+        "Bikenibeu Village"
     ],
     "qs:name":"Bikenibeu Village",
     "qs:photos_9r":0,
@@ -74,7 +92,7 @@
         }
     ],
     "wof:id":890424303,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938153,
     "wof:name":"Bikenibeu Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/424/307/890424307.geojson
+++ b/data/890/424/307/890424307.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Eita Village"
     ],
+    "name:deu_x_preferred":[
+        "Eita"
+    ],
     "name:eng_x_preferred":[
         "Eita"
     ],
@@ -44,6 +47,9 @@
         "Eita"
     ],
     "name:por_x_preferred":[
+        "Eita"
+    ],
+    "name:spa_x_preferred":[
         "Eita"
     ],
     "name:swe_x_preferred":[
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890424307,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938150,
     "wof:name":"Eita Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/424/309/890424309.geojson
+++ b/data/890/424/309/890424309.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Kiribati Uniting Church"
+    ],
     "name:eng_x_preferred":[
         "Kiribati Uniting Church"
     ],
@@ -27,6 +30,18 @@
     ],
     "name:fra_x_preferred":[
         "Kiribati Uniting Church"
+    ],
+    "name:ita_x_preferred":[
+        "Kiribati Uniting Church"
+    ],
+    "name:por_x_preferred":[
+        "Kiribati Uniting Church"
+    ],
+    "name:spa_x_preferred":[
+        "Kiribati Uniting Church"
+    ],
+    "name:vec_x_preferred":[
+        "Ceza Unia del Kiribati"
     ],
     "qs:name":"Tangintebu Village",
     "qs:photos_9r":0,
@@ -55,7 +70,7 @@
         }
     ],
     "wof:id":890424309,
-    "wof:lastmodified":1566727657,
+    "wof:lastmodified":1690938150,
     "wof:name":"Tangintebu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/311/890424311.geojson
+++ b/data/890/424/311/890424311.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -249,6 +273,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -287,7 +317,7 @@
         }
     ],
     "wof:id":890424311,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938154,
     "wof:name":"Abarao Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/428/739/890428739.geojson
+++ b/data/890/428/739/890428739.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -32,6 +41,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -121,7 +136,7 @@
         }
     ],
     "wof:id":890428739,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938159,
     "wof:name":"Tanimaiaki Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/745/890428745.geojson
+++ b/data/890/428/745/890428745.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Takarano Village"
     ],
+    "name:deu_x_preferred":[
+        "Takarano"
+    ],
     "name:eng_x_preferred":[
+        "Takarano"
+    ],
+    "name:fra_x_preferred":[
         "Takarano"
     ],
     "name:nld_x_preferred":[
@@ -61,7 +67,7 @@
         }
     ],
     "wof:id":890428745,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938160,
     "wof:name":"Takarano Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/749/890428749.geojson
+++ b/data/890/428/749/890428749.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062a\u0639\u0644\u064a\u0645 \u0641\u064a \u0643\u064a\u0631\u064a\u0628\u0627\u062a\u064a"
     ],
+    "name:deu_x_preferred":[
+        "Bildung in Kiribati"
+    ],
     "name:eng_x_preferred":[
         "education in Kiribati"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041e\u0431\u0440\u0430\u0437\u043e\u0432\u0430\u043d\u0438\u0435 \u0432 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
+    "name:spa_x_preferred":[
+        "educaci\u00f3n en Kiribati"
     ],
     "name:und_x_variant":[
         "Tabwiroa"
@@ -67,7 +73,7 @@
         }
     ],
     "wof:id":890428749,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938159,
     "wof:name":"Tabuiroa Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/751/890428751.geojson
+++ b/data/890/428/751/890428751.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Onotoa"
     ],
+    "name:ces_x_preferred":[
+        "Onotoa"
+    ],
     "name:deu_x_preferred":[
         "Onotoa"
     ],
@@ -32,6 +35,12 @@
         "\u039f\u03bd\u03bf\u03c4\u03cc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Onotoa"
+    ],
+    "name:est_x_preferred":[
+        "Onotoa"
+    ],
+    "name:fao_x_preferred":[
         "Onotoa"
     ],
     "name:fas_x_preferred":[
@@ -124,7 +133,7 @@
         }
     ],
     "wof:id":890428751,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938159,
     "wof:name":"Tabuarorae Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/753/890428753.geojson
+++ b/data/890/428/753/890428753.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -280,7 +310,7 @@
         }
     ],
     "wof:id":890428753,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938159,
     "wof:name":"Taborio Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/755/890428755.geojson
+++ b/data/890/428/755/890428755.geojson
@@ -28,6 +28,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -35,6 +38,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -135,7 +144,7 @@
         }
     ],
     "wof:id":890428755,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938158,
     "wof:name":"Tabiang Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/759/890428759.geojson
+++ b/data/890/428/759/890428759.geojson
@@ -22,7 +22,16 @@
     "name:ceb_x_preferred":[
         "Roreti Village"
     ],
+    "name:deu_x_preferred":[
+        "Roreti"
+    ],
     "name:eng_x_preferred":[
+        "Roreti"
+    ],
+    "name:fas_x_preferred":[
+        "\u0631\u0648\u0631\u062a\u06cc"
+    ],
+    "name:fra_x_preferred":[
         "Roreti"
     ],
     "name:nld_x_preferred":[
@@ -30,6 +39,9 @@
     ],
     "name:pol_x_preferred":[
         "Roreti"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u043e\u0440\u0435\u0442\u0438"
     ],
     "name:swe_x_preferred":[
         "Roreti Village"
@@ -65,7 +77,7 @@
         }
     ],
     "wof:id":890428759,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938160,
     "wof:name":"Roreti Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/429/003/890429003.geojson
+++ b/data/890/429/003/890429003.geojson
@@ -18,6 +18,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":6.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0643\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0438"
     ],
@@ -31,6 +34,9 @@
         "\u039c\u03b1\u03c1\u03b1\u03ba\u03ad\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Marakei"
+    ],
+    "name:est_x_preferred":[
         "Marakei"
     ],
     "name:fas_x_preferred":[
@@ -69,6 +75,9 @@
     "name:nld_x_preferred":[
         "Marakei"
     ],
+    "name:pol_x_preferred":[
+        "Marakei"
+    ],
     "name:por_x_preferred":[
         "Marakei"
     ],
@@ -83,6 +92,9 @@
     ],
     "name:tur_x_preferred":[
         "Marakei"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0440\u0430\u043a\u0435\u0457"
     ],
     "name:zho_x_preferred":[
         "\u99ac\u62c9\u51f1\u74b0\u7901"
@@ -113,7 +125,7 @@
         }
     ],
     "wof:id":890429003,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938161,
     "wof:name":"Marakei",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/087/890429087.geojson
+++ b/data/890/429/087/890429087.geojson
@@ -30,6 +30,9 @@
     "name:eng_x_preferred":[
         "Nikunau"
     ],
+    "name:est_x_preferred":[
+        "Nikunau"
+    ],
     "name:fas_x_preferred":[
         "\u0646\u06cc\u06a9\u0648\u0646\u0627\u0648"
     ],
@@ -64,6 +67,9 @@
         "\u041d\u0438\u043a\u0443\u043d\u0430\u0443"
     ],
     "name:nld_x_preferred":[
+        "Nikunau"
+    ],
+    "name:pol_x_preferred":[
         "Nikunau"
     ],
     "name:por_x_preferred":[
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":890429087,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938161,
     "wof:name":"Nikunau",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/089/890429089.geojson
+++ b/data/890/429/089/890429089.geojson
@@ -24,6 +24,9 @@
     "name:ceb_x_preferred":[
         "Onotoa"
     ],
+    "name:ces_x_preferred":[
+        "Onotoa"
+    ],
     "name:deu_x_preferred":[
         "Onotoa"
     ],
@@ -31,6 +34,12 @@
         "\u039f\u03bd\u03bf\u03c4\u03cc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Onotoa"
+    ],
+    "name:est_x_preferred":[
+        "Onotoa"
+    ],
+    "name:fao_x_preferred":[
         "Onotoa"
     ],
     "name:fas_x_preferred":[
@@ -119,7 +128,7 @@
         }
     ],
     "wof:id":890429089,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938161,
     "wof:name":"Onotoa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/663/890429663.geojson
+++ b/data/890/429/663/890429663.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Tebanga Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890429663,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938161,
     "wof:name":"Tebanga Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/665/890429665.geojson
+++ b/data/890/429/665/890429665.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Temwangaua Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890429665,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938162,
     "wof:name":"Temwangaua Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/669/890429669.geojson
+++ b/data/890/429/669/890429669.geojson
@@ -37,6 +37,9 @@
     "name:epo_x_preferred":[
         "Maiana"
     ],
+    "name:est_x_preferred":[
+        "Maiana"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u06cc\u0627\u0646\u0627"
     ],
@@ -91,6 +94,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u4e9e\u7d0d\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u9081\u4e9e\u7d0d\u74b0\u7901"
+    ],
     "qs:name":"Tebwangetua Village",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890429669,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938160,
     "wof:name":"Tebwangetua Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/781/890429781.geojson
+++ b/data/890/429/781/890429781.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Takaeang"
     ],
+    "name:deu_x_preferred":[
+        "Takaeang"
+    ],
     "name:eng_x_preferred":[
         "Takaeang"
     ],
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890429781,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938162,
     "wof:name":"Takaeang Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/785/890429785.geojson
+++ b/data/890/429/785/890429785.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Makin"
+    ],
     "name:ceb_x_preferred":[
         "Makin Island"
+    ],
+    "name:ceb_x_variant":[
+        "Makin"
+    ],
+    "name:ces_x_preferred":[
+        "Makin"
     ],
     "name:dan_x_preferred":[
         "Makin"
@@ -32,6 +41,12 @@
         "\u039c\u03b1\u03ba\u03af\u03bd \u039d\u03ae\u03c3\u03bf\u03c2"
     ],
     "name:eng_x_preferred":[
+        "Makin"
+    ],
+    "name:est_x_preferred":[
+        "Makin"
+    ],
+    "name:fao_x_preferred":[
         "Makin"
     ],
     "name:fas_x_preferred":[
@@ -48,6 +63,9 @@
     ],
     "name:ita_x_preferred":[
         "Isole Makin"
+    ],
+    "name:ita_x_variant":[
+        "Makin"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30ad\u30f3\u5cf6"
@@ -118,7 +136,7 @@
         }
     ],
     "wof:id":890429785,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938160,
     "wof:name":"Kiebu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/436/045/890436045.geojson
+++ b/data/890/436/045/890436045.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Betania Village"
+    ],
+    "name:deu_x_preferred":[
+        "Betania"
+    ],
     "name:eng_x_preferred":[
+        "Betania"
+    ],
+    "name:fra_x_preferred":[
         "Betania"
     ],
     "name:nld_x_preferred":[
         "Betania"
+    ],
+    "name:swe_x_preferred":[
+        "Betania Village"
     ],
     "qs:name":"Tereitaki Village",
     "qs:photos_9r":0,
@@ -55,7 +67,7 @@
         }
     ],
     "wof:id":890436045,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938156,
     "wof:name":"Tereitaki Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/436/545/890436545.geojson
+++ b/data/890/436/545/890436545.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -32,6 +41,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":890436545,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938156,
     "wof:name":"Bikati Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/439/887/890439887.geojson
+++ b/data/890/439/887/890439887.geojson
@@ -19,10 +19,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Taburao"
+    ],
     "name:ceb_x_preferred":[
         "Taburao Village"
     ],
+    "name:deu_x_preferred":[
+        "Taburao"
+    ],
     "name:eng_x_preferred":[
+        "Taburao"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u0628\u0648\u0631\u0627\u0626\u0648"
+    ],
+    "name:fra_x_preferred":[
         "Taburao"
     ],
     "name:nld_x_preferred":[
@@ -31,11 +43,17 @@
     "name:pol_x_preferred":[
         "Taburao"
     ],
+    "name:rus_x_preferred":[
+        "\u0422\u0430\u0431\u0443\u0440\u0430\u043e"
+    ],
     "name:swe_x_preferred":[
         "Taburao Village"
     ],
     "name:und_x_variant":[
         "Tebero"
+    ],
+    "name:zho_x_preferred":[
+        "\u5854\u5e03\u62c9\u5967"
     ],
     "qs:name":"Taburao Village",
     "qs:photos_9r":0,
@@ -68,7 +86,7 @@
         }
     ],
     "wof:id":890439887,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938154,
     "wof:name":"Taburao Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/439/931/890439931.geojson
+++ b/data/890/439/931/890439931.geojson
@@ -22,11 +22,20 @@
     "name:ceb_x_preferred":[
         "Utiroa Village"
     ],
+    "name:deu_x_preferred":[
+        "Utiroa"
+    ],
     "name:eng_x_preferred":[
         "Utiroa"
     ],
     "name:fas_x_preferred":[
         "\u06cc\u0648\u062a\u06cc\u0631\u0627"
+    ],
+    "name:fra_x_preferred":[
+        "Utiroa"
+    ],
+    "name:ita_x_preferred":[
+        "Utiroa"
     ],
     "name:nld_x_preferred":[
         "Utiroa"
@@ -34,8 +43,17 @@
     "name:pol_x_preferred":[
         "Utiroa"
     ],
+    "name:por_x_preferred":[
+        "Utiroa"
+    ],
+    "name:spa_x_preferred":[
+        "Utiroa"
+    ],
     "name:swe_x_preferred":[
         "Utiroa Village"
+    ],
+    "name:tur_x_preferred":[
+        "Utiroa"
     ],
     "qs:name":"Utiroa Village",
     "qs:photos_9r":0,
@@ -68,7 +86,7 @@
         }
     ],
     "wof:id":890439931,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938154,
     "wof:name":"Utiroa Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/439/935/890439935.geojson
+++ b/data/890/439/935/890439935.geojson
@@ -22,8 +22,14 @@
     "name:ceb_x_preferred":[
         "Matang Village"
     ],
+    "name:deu_x_preferred":[
+        "Matang"
+    ],
     "name:eng_x_preferred":[
         "Temaraia"
+    ],
+    "name:fra_x_preferred":[
+        "Matang"
     ],
     "name:nld_x_preferred":[
         "Temaraia"
@@ -58,7 +64,7 @@
         }
     ],
     "wof:id":890439935,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938155,
     "wof:name":"Matang Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/440/147/890440147.geojson
+++ b/data/890/440/147/890440147.geojson
@@ -25,6 +25,9 @@
     "name:ben_x_preferred":[
         "\u09ac\u09c1\u09a4\u09be\u09b0\u09bf\u09a4\u09be\u09b0\u09bf"
     ],
+    "name:ces_x_preferred":[
+        "Butaritari"
+    ],
     "name:eng_x_preferred":[
         "Butaritari"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890440147,
-    "wof:lastmodified":1636500710,
+    "wof:lastmodified":1690938142,
     "wof:name":"Butaritari",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/563/890442563.geojson
+++ b/data/890/442/563/890442563.geojson
@@ -22,6 +22,12 @@
     "name:bel_x_preferred":[
         "\u0410\u0442\u043e\u043b \u0422\u0430\u0431\u0443\u0430\u044d\u0440\u0430\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Tabuaeran"
+    ],
+    "name:ceb_x_preferred":[
+        "Tabuaeran Island"
+    ],
     "name:ces_x_preferred":[
         "Tabuaeran"
     ],
@@ -79,6 +85,12 @@
     "name:nld_x_preferred":[
         "Tabuaeran"
     ],
+    "name:nob_x_preferred":[
+        "Fanning\u00f8ya"
+    ],
+    "name:por_x_preferred":[
+        "Tabuaeran"
+    ],
     "name:ron_x_preferred":[
         "Tabuaeran"
     ],
@@ -96,6 +108,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0431\u0443\u0430\u0435\u0440\u0430\u043d"
+    ],
+    "name:vie_x_preferred":[
+        "Tabuaeran"
     ],
     "name:zho_x_preferred":[
         "\u5854\u5e03\u963f\u57c3\u862d\u74b0\u7901"
@@ -126,7 +141,7 @@
         }
     ],
     "wof:id":890442563,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938167,
     "wof:name":"Tenenebo Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/569/890442569.geojson
+++ b/data/890/442/569/890442569.geojson
@@ -31,11 +31,20 @@
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "South Tarawa"
+    ],
     "name:aze_x_preferred":[
         "C\u0259nubi Tarava"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a3 \u09a4\u09be\u09b0\u09be\u0993\u09af\u09bc\u09be"
@@ -97,6 +106,9 @@
     "name:gla_x_preferred":[
         "South Tarawa"
     ],
+    "name:gle_x_preferred":[
+        "Tarawa Theas"
+    ],
     "name:glg_x_preferred":[
         "Tarawa Sur"
     ],
@@ -105,6 +117,9 @@
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Tarawa"
+    ],
+    "name:hau_x_preferred":[
+        "Tarawa ta Kudu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05d0\u05e8\u05d0\u05d5\u05d5\u05d4"
@@ -181,6 +196,9 @@
     "name:oci_x_preferred":[
         "Tarawa Sud"
     ],
+    "name:oss_x_preferred":[
+        "\u0425\u0443\u0441\u0441\u0430\u0440 \u0422\u0430\u0440\u0430\u0432\u00e6"
+    ],
     "name:pan_x_preferred":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a24\u0a30\u0a3e\u0a35\u0a3e"
     ],
@@ -211,6 +229,9 @@
     "name:sqi_x_preferred":[
         "South Tarawa"
     ],
+    "name:srd_x_preferred":[
+        "Tarawa Sud"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0430 \u0422\u0430\u0440\u0430\u0432\u0430"
     ],
@@ -225,6 +246,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c24\u0c30\u0c3e\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0432\u0430\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Timog Tarawa"
@@ -246,6 +270,12 @@
     ],
     "name:war_x_preferred":[
         "Salatan Tarawa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5357\u5854\u62c9\u74e6"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10d1\u10df\u10d0\u10d7\u10d4 \u10e2\u10d0\u10e0\u10d0\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u5357\u9054\u7dad\u83ef"
@@ -280,7 +310,7 @@
         }
     ],
     "wof:id":890442569,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938166,
     "wof:name":"Tanaea Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/605/890442605.geojson
+++ b/data/890/442/605/890442605.geojson
@@ -28,6 +28,9 @@
     "name:deu_x_preferred":[
         "Ijaki"
     ],
+    "name:deu_x_variant":[
+        "Aiaki"
+    ],
     "name:eng_x_preferred":[
         "Aiaki"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:por_x_preferred":[
         "Ijaki"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0439\u0430\u043a\u0438"
     ],
     "name:swe_x_preferred":[
         "Aiaki"
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":890442605,
-    "wof:lastmodified":1566727661,
+    "wof:lastmodified":1690938167,
     "wof:name":"Aiaki",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/444/215/890444215.geojson
+++ b/data/890/444/215/890444215.geojson
@@ -22,14 +22,26 @@
     "name:ceb_x_preferred":[
         "Tabiauea Village"
     ],
+    "name:deu_x_preferred":[
+        "Tebiauea"
+    ],
     "name:eng_x_preferred":[
         "Tabiauea"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u0628\u06cc\u0627\u0648\u0626\u0627"
+    ],
+    "name:fra_x_preferred":[
+        "Tebiauea"
     ],
     "name:nld_x_preferred":[
         "Tabiauea"
     ],
     "name:pol_x_preferred":[
         "Tabiauea"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u0435\u0431\u0438\u0430\u0443\u044d\u0430"
     ],
     "name:swe_x_preferred":[
         "Tabiauea Village"
@@ -64,7 +76,7 @@
         }
     ],
     "wof:id":890444215,
-    "wof:lastmodified":1566727660,
+    "wof:lastmodified":1690938160,
     "wof:name":"Tabiauea Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/327/890445327.geojson
+++ b/data/890/445/327/890445327.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -32,6 +41,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -121,7 +136,7 @@
         }
     ],
     "wof:id":890445327,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938170,
     "wof:name":"Tabonuea Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/329/890445329.geojson
+++ b/data/890/445/329/890445329.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Tabontebike Village"
     ],
+    "name:deu_x_preferred":[
+        "Tabontebike"
+    ],
     "name:eng_x_preferred":[
+        "Tabontebike"
+    ],
+    "name:fra_x_preferred":[
         "Tabontebike"
     ],
     "name:nld_x_preferred":[
@@ -64,7 +70,7 @@
         }
     ],
     "wof:id":890445329,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938170,
     "wof:name":"Tabontebike Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/331/890445331.geojson
+++ b/data/890/445/331/890445331.geojson
@@ -19,7 +19,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Tabomatang"
+    ],
     "name:eng_x_preferred":[
+        "Tabomatang"
+    ],
+    "name:fra_x_preferred":[
         "Tabomatang"
     ],
     "name:nld_x_preferred":[
@@ -52,7 +58,7 @@
         }
     ],
     "wof:id":890445331,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938167,
     "wof:name":"Tabomatang Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/333/890445333.geojson
+++ b/data/890/445/333/890445333.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Nikumanu Village"
     ],
+    "name:deu_x_preferred":[
+        "Nikumanu"
+    ],
     "name:eng_x_preferred":[
+        "Nikumanu"
+    ],
+    "name:fra_x_preferred":[
         "Nikumanu"
     ],
     "name:nld_x_preferred":[
@@ -61,7 +67,7 @@
         }
     ],
     "wof:id":890445333,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938168,
     "wof:name":"Nikumanu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/643/890445643.geojson
+++ b/data/890/445/643/890445643.geojson
@@ -21,6 +21,12 @@
     "name:bel_x_preferred":[
         "\u0410\u0442\u043e\u043b \u0422\u0430\u0431\u0443\u0430\u044d\u0440\u0430\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Tabuaeran"
+    ],
+    "name:ceb_x_preferred":[
+        "Tabuaeran Island"
+    ],
     "name:ces_x_preferred":[
         "Tabuaeran"
     ],
@@ -81,6 +87,12 @@
     "name:nld_x_preferred":[
         "Tabuaeran"
     ],
+    "name:nob_x_preferred":[
+        "Fanning\u00f8ya"
+    ],
+    "name:por_x_preferred":[
+        "Tabuaeran"
+    ],
     "name:ron_x_preferred":[
         "Tabuaeran"
     ],
@@ -107,6 +119,9 @@
     ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o Tabuaeran"
+    ],
+    "name:vie_x_variant":[
+        "Tabuaeran"
     ],
     "name:zho_cn_x_preferred":[
         "\u5854\u5e03\u963f\u57c3\u5170\u73af\u7901"
@@ -143,7 +158,7 @@
         }
     ],
     "wof:id":890445643,
-    "wof:lastmodified":1636500711,
+    "wof:lastmodified":1690938167,
     "wof:name":"Tabuaeran",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/649/890445649.geojson
+++ b/data/890/445/649/890445649.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0627\u0631\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0627\u0631\u0627\u0648\u0627"
+    ],
     "name:ast_x_preferred":[
         "Tarawa"
     ],
@@ -38,6 +41,9 @@
     ],
     "name:bos_x_preferred":[
         "Tarawa"
+    ],
+    "name:bul_x_preferred":[
+        "\u0422\u0430\u0440\u0430\u0443\u0430"
     ],
     "name:cat_x_preferred":[
         "Tarawa"
@@ -141,6 +147,9 @@
     "name:msa_x_preferred":[
         "Tarawa"
     ],
+    "name:nep_x_preferred":[
+        "\u0924\u093e\u0930\u093e\u0935\u093e"
+    ],
     "name:nld_x_preferred":[
         "Tarawa"
     ],
@@ -155,6 +164,9 @@
     ],
     "name:por_x_preferred":[
         "Tarawa"
+    ],
+    "name:pus_x_preferred":[
+        "\u062a\u0627\u0631\u0627\u0648\u0627"
     ],
     "name:rus_x_preferred":[
         "\u0422\u0430\u0440\u0430\u0432\u0430"
@@ -219,6 +231,9 @@
     "name:war_x_preferred":[
         "Tarawa"
     ],
+    "name:wuu_x_preferred":[
+        "\u5854\u62c9\u74e6\u73af\u7901"
+    ],
     "name:yue_x_preferred":[
         "\u9054\u7dad\u83ef"
     ],
@@ -251,7 +266,7 @@
         }
     ],
     "wof:id":890445649,
-    "wof:lastmodified":1636500711,
+    "wof:lastmodified":1690938169,
     "wof:name":"Tarawa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/651/890445651.geojson
+++ b/data/890/445/651/890445651.geojson
@@ -18,6 +18,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":6.0,
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0631\u0627\u064a\u0646\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0422\u044d\u0440\u0430\u0439\u043d\u0430"
     ],
@@ -37,6 +40,9 @@
         "Teraina"
     ],
     "name:epo_x_preferred":[
+        "Teraina"
+    ],
+    "name:est_x_preferred":[
         "Teraina"
     ],
     "name:fas_x_preferred":[
@@ -125,7 +131,7 @@
         }
     ],
     "wof:id":890445651,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938168,
     "wof:name":"Teraina",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/655/890445655.geojson
+++ b/data/890/445/655/890445655.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0631\u0627\u064a\u0646\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0422\u044d\u0440\u0430\u0439\u043d\u0430"
     ],
@@ -38,6 +41,9 @@
         "Teraina"
     ],
     "name:epo_x_preferred":[
+        "Teraina"
+    ],
+    "name:est_x_preferred":[
         "Teraina"
     ],
     "name:fas_x_preferred":[
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":890445655,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938170,
     "wof:name":"Uteute Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/659/890445659.geojson
+++ b/data/890/445/659/890445659.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0631\u0627\u064a\u0646\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0422\u044d\u0440\u0430\u0439\u043d\u0430"
     ],
@@ -38,6 +41,9 @@
         "Teraina"
     ],
     "name:epo_x_preferred":[
+        "Teraina"
+    ],
+    "name:est_x_preferred":[
         "Teraina"
     ],
     "name:fas_x_preferred":[
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":890445659,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938168,
     "wof:name":"Arabata Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/667/890445667.geojson
+++ b/data/890/445/667/890445667.geojson
@@ -22,6 +22,12 @@
     "name:bel_x_preferred":[
         "\u0410\u0442\u043e\u043b \u0422\u0430\u0431\u0443\u0430\u044d\u0440\u0430\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Tabuaeran"
+    ],
+    "name:ceb_x_preferred":[
+        "Tabuaeran Island"
+    ],
     "name:ces_x_preferred":[
         "Tabuaeran"
     ],
@@ -79,6 +85,12 @@
     "name:nld_x_preferred":[
         "Tabuaeran"
     ],
+    "name:nob_x_preferred":[
+        "Fanning\u00f8ya"
+    ],
+    "name:por_x_preferred":[
+        "Tabuaeran"
+    ],
     "name:ron_x_preferred":[
         "Tabuaeran"
     ],
@@ -96,6 +108,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0431\u0443\u0430\u0435\u0440\u0430\u043d"
+    ],
+    "name:vie_x_preferred":[
+        "Tabuaeran"
     ],
     "name:zho_x_preferred":[
         "\u5854\u5e03\u963f\u57c3\u862d\u74b0\u7901"
@@ -126,7 +141,7 @@
         }
     ],
     "wof:id":890445667,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938168,
     "wof:name":"Aramari Gilberts Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/679/890445679.geojson
+++ b/data/890/445/679/890445679.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0431\u0430\u0438\u0430\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Abaiang"
+    ],
     "name:ceb_x_preferred":[
         "Abaiang"
     ],
@@ -79,6 +82,9 @@
     "name:nld_x_preferred":[
         "Abaiang"
     ],
+    "name:pol_x_preferred":[
+        "Abaiang"
+    ],
     "name:por_x_preferred":[
         "Abaiang"
     ],
@@ -127,7 +133,7 @@
         }
     ],
     "wof:id":890445679,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938169,
     "wof:name":"Nuotaea Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/683/890445683.geojson
+++ b/data/890/445/683/890445683.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0431\u0430\u0438\u0430\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Abaiang"
+    ],
     "name:ceb_x_preferred":[
         "Abaiang"
     ],
@@ -79,6 +82,9 @@
     "name:nld_x_preferred":[
         "Abaiang"
     ],
+    "name:pol_x_preferred":[
+        "Abaiang"
+    ],
     "name:por_x_preferred":[
         "Abaiang"
     ],
@@ -127,7 +133,7 @@
         }
     ],
     "wof:id":890445683,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938170,
     "wof:name":"Ribono Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/685/890445685.geojson
+++ b/data/890/445/685/890445685.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0431\u0430\u0438\u0430\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Abaiang"
+    ],
     "name:ceb_x_preferred":[
         "Abaiang"
     ],
@@ -79,6 +82,9 @@
     "name:nld_x_preferred":[
         "Abaiang"
     ],
+    "name:pol_x_preferred":[
+        "Abaiang"
+    ],
     "name:por_x_preferred":[
         "Abaiang"
     ],
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":890445685,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938169,
     "wof:name":"Aoneaba Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/445/687/890445687.geojson
+++ b/data/890/445/687/890445687.geojson
@@ -19,10 +19,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Taburao"
+    ],
     "name:ceb_x_preferred":[
         "Taburao Village"
     ],
+    "name:deu_x_preferred":[
+        "Taburao"
+    ],
     "name:eng_x_preferred":[
+        "Taburao"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u0628\u0648\u0631\u0627\u0626\u0648"
+    ],
+    "name:fra_x_preferred":[
         "Taburao"
     ],
     "name:nld_x_preferred":[
@@ -31,8 +43,14 @@
     "name:pol_x_preferred":[
         "Taburao"
     ],
+    "name:rus_x_preferred":[
+        "\u0422\u0430\u0431\u0443\u0440\u0430\u043e"
+    ],
     "name:swe_x_preferred":[
         "Taburao Village"
+    ],
+    "name:zho_x_preferred":[
+        "\u5854\u5e03\u62c9\u5967"
     ],
     "qs:name":"Tebero Village",
     "qs:photos_9r":0,
@@ -61,7 +79,7 @@
         }
     ],
     "wof:id":890445687,
-    "wof:lastmodified":1566727662,
+    "wof:lastmodified":1690938168,
     "wof:name":"Tebero Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/451/673/890451673.geojson
+++ b/data/890/451/673/890451673.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Betania Village"
+    ],
+    "name:deu_x_preferred":[
+        "Betania"
+    ],
     "name:eng_x_preferred":[
+        "Betania"
+    ],
+    "name:fra_x_preferred":[
         "Betania"
     ],
     "name:nld_x_preferred":[
         "Betania"
+    ],
+    "name:swe_x_preferred":[
+        "Betania Village"
     ],
     "qs:name":"Betania Village",
     "qs:photos_9r":0,
@@ -51,7 +63,7 @@
         }
     ],
     "wof:id":890451673,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938171,
     "wof:name":"Betania Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/451/687/890451687.geojson
+++ b/data/890/451/687/890451687.geojson
@@ -22,8 +22,17 @@
     "name:eng_x_preferred":[
         "Bah\u00e1'\u00ed Faith in Kiribati"
     ],
+    "name:ita_x_preferred":[
+        "Bahai nelle Kiribati"
+    ],
+    "name:rus_x_preferred":[
+        "\u0431\u0430\u0445\u0430\u0438 \u0432 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"
+    ],
     "name:spa_x_preferred":[
         "Baha\u00edsmo en Kiribati"
+    ],
+    "name:spa_x_variant":[
+        "Fe bah\u00e1'\u00ed en Kiribati"
     ],
     "qs:name":"Tenatorua Village",
     "qs:photos_9r":0,
@@ -52,7 +61,7 @@
         }
     ],
     "wof:id":890451687,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938171,
     "wof:name":"Tenatorua Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/451/695/890451695.geojson
+++ b/data/890/451/695/890451695.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0627\u0631\u0627\u0646\u0648\u0643\u0627"
+    ],
     "name:aze_x_preferred":[
         "Aranuka adas\u0131"
     ],
@@ -73,6 +76,9 @@
     "name:nld_x_preferred":[
         "Aranuka"
     ],
+    "name:pol_x_preferred":[
+        "Aranuka"
+    ],
     "name:por_x_preferred":[
         "Aranuka"
     ],
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":890451695,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938171,
     "wof:name":"Baurua Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/451/697/890451697.geojson
+++ b/data/890/451/697/890451697.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Makin"
+    ],
     "name:ceb_x_preferred":[
         "Makin Island"
+    ],
+    "name:ceb_x_variant":[
+        "Makin"
+    ],
+    "name:ces_x_preferred":[
+        "Makin"
     ],
     "name:dan_x_preferred":[
         "Makin"
@@ -32,6 +41,12 @@
         "\u039c\u03b1\u03ba\u03af\u03bd \u039d\u03ae\u03c3\u03bf\u03c2"
     ],
     "name:eng_x_preferred":[
+        "Makin"
+    ],
+    "name:est_x_preferred":[
+        "Makin"
+    ],
+    "name:fao_x_preferred":[
         "Makin"
     ],
     "name:fas_x_preferred":[
@@ -48,6 +63,9 @@
     ],
     "name:ita_x_preferred":[
         "Isole Makin"
+    ],
+    "name:ita_x_variant":[
+        "Makin"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30ad\u30f3\u5cf6"
@@ -118,7 +136,7 @@
         }
     ],
     "wof:id":890451697,
-    "wof:lastmodified":1566727663,
+    "wof:lastmodified":1690938172,
     "wof:name":"Makin Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/453/199/890453199.geojson
+++ b/data/890/453/199/890453199.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0646\u0627\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0646\u0627\u0628\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0411\u0430\u043d\u0430\u0431\u0430"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:ces_x_preferred":[
         "Banaba"
+    ],
+    "name:che_x_preferred":[
+        "\u041e\u0448\u0435\u043d"
     ],
     "name:dan_x_preferred":[
         "Banaba"
@@ -55,6 +61,9 @@
     "name:est_x_preferred":[
         "Banaba"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0646\u0627\u0628\u0627"
+    ],
     "name:fin_x_preferred":[
         "Banaba"
     ],
@@ -68,6 +77,12 @@
         "\u05d1\u05e0\u05d1\u05d4"
     ],
     "name:hrv_x_preferred":[
+        "Banaba"
+    ],
+    "name:ind_x_preferred":[
+        "Pulau Banaba"
+    ],
+    "name:isl_x_preferred":[
         "Banaba"
     ],
     "name:ita_x_preferred":[
@@ -117,6 +132,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0411\u0430\u043d\u0430\u0431\u0430"
+    ],
+    "name:slk_x_preferred":[
+        "Banaba"
     ],
     "name:spa_x_preferred":[
         "Banaba"
@@ -176,7 +194,7 @@
         }
     ],
     "wof:id":890453199,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938158,
     "wof:name":"Antereen Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/453/479/890453479.geojson
+++ b/data/890/453/479/890453479.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Onotoa"
     ],
+    "name:ces_x_preferred":[
+        "Onotoa"
+    ],
     "name:deu_x_preferred":[
         "Onotoa"
     ],
@@ -32,6 +35,12 @@
         "\u039f\u03bd\u03bf\u03c4\u03cc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Onotoa"
+    ],
+    "name:est_x_preferred":[
+        "Onotoa"
+    ],
+    "name:fao_x_preferred":[
         "Onotoa"
     ],
     "name:fas_x_preferred":[
@@ -124,7 +133,7 @@
         }
     ],
     "wof:id":890453479,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938157,
     "wof:name":"Tanaeang Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/453/555/890453555.geojson
+++ b/data/890/453/555/890453555.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0411\u0443\u0442\u0430\u0440\u044b\u0442\u0430\u0440\u044b"
+    ],
+    "name:cat_x_preferred":[
+        "Butaritari"
+    ],
     "name:ceb_x_preferred":[
         "Butaritari Atoll"
+    ],
+    "name:ces_x_preferred":[
+        "Butaritari"
     ],
     "name:deu_x_preferred":[
         "Butaritari"
@@ -32,6 +41,12 @@
         "Butaritari"
     ],
     "name:epo_x_preferred":[
+        "Butaritari"
+    ],
+    "name:est_x_preferred":[
+        "Butaritari"
+    ],
+    "name:fao_x_preferred":[
         "Butaritari"
     ],
     "name:fas_x_preferred":[
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":890453555,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938158,
     "wof:name":"Ukiangang Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/179/890454179.geojson
+++ b/data/890/454/179/890454179.geojson
@@ -19,8 +19,14 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Koinawa"
+    ],
     "name:eng_x_preferred":[
         "Koinawa"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u06cc\u0646\u0627\u0648\u0627"
     ],
     "name:fra_x_preferred":[
         "Koinawa"
@@ -62,7 +68,7 @@
         }
     ],
     "wof:id":890454179,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938157,
     "wof:name":"Morikao Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/454/181/890454181.geojson
+++ b/data/890/454/181/890454181.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Marenanuka"
+    ],
     "name:eng_x_preferred":[
         "Marenanuka"
     ],
@@ -30,6 +33,9 @@
     ],
     "name:und_x_variant":[
         "Maranenuka Village"
+    ],
+    "name:zho_x_preferred":[
+        "\u99ac\u52d2\u7d0d\u52aa\u5361"
     ],
     "qs:name":"Marenanuka Village",
     "qs:photos_9r":0,
@@ -58,7 +64,7 @@
         }
     ],
     "wof:id":890454181,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938157,
     "wof:name":"Marenanuka Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/359/890454359.geojson
+++ b/data/890/454/359/890454359.geojson
@@ -22,6 +22,12 @@
     "name:bel_x_preferred":[
         "\u0410\u0442\u043e\u043b \u0422\u0430\u0431\u0443\u0430\u044d\u0440\u0430\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Tabuaeran"
+    ],
+    "name:ceb_x_preferred":[
+        "Tabuaeran Island"
+    ],
     "name:ces_x_preferred":[
         "Tabuaeran"
     ],
@@ -79,6 +85,12 @@
     "name:nld_x_preferred":[
         "Tabuaeran"
     ],
+    "name:nob_x_preferred":[
+        "Fanning\u00f8ya"
+    ],
+    "name:por_x_preferred":[
+        "Tabuaeran"
+    ],
     "name:ron_x_preferred":[
         "Tabuaeran"
     ],
@@ -96,6 +108,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0431\u0443\u0430\u0435\u0440\u0430\u043d"
+    ],
+    "name:vie_x_preferred":[
+        "Tabuaeran"
     ],
     "name:zho_x_preferred":[
         "\u5854\u5e03\u963f\u57c3\u862d\u74b0\u7901"
@@ -126,7 +141,7 @@
         }
     ],
     "wof:id":890454359,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938157,
     "wof:name":"Aontena Gilberts Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/361/890454361.geojson
+++ b/data/890/454/361/890454361.geojson
@@ -31,6 +31,15 @@
     "name:epo_x_preferred":[
         "Pollando"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0648\u0644\u0646\u062f"
+    ],
+    "name:fra_x_preferred":[
+        "Poland"
+    ],
+    "name:ita_x_preferred":[
+        "Poland"
+    ],
     "name:jpn_x_preferred":[
         "\u30dd\u30fc\u30e9\u30f3\u30c9"
     ],
@@ -41,6 +50,12 @@
         "Poland"
     ],
     "name:pol_x_preferred":[
+        "Poland"
+    ],
+    "name:por_x_preferred":[
+        "Poland"
+    ],
+    "name:spa_x_preferred":[
         "Poland"
     ],
     "name:swe_x_preferred":[
@@ -77,7 +92,7 @@
         }
     ],
     "wof:id":890454361,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938157,
     "wof:name":"Poland Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/454/363/890454363.geojson
+++ b/data/890/454/363/890454363.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Tabwakea"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u0628\u0648\u0627\u06a9\u0626\u0627"
+    ],
     "name:fra_x_preferred":[
         "Tabwakea"
     ],
@@ -37,7 +40,13 @@
     "name:nld_x_preferred":[
         "Tabwakea"
     ],
+    "name:pol_x_preferred":[
+        "Tabwakea"
+    ],
     "name:por_x_preferred":[
+        "Tabwakea"
+    ],
+    "name:spa_x_preferred":[
         "Tabwakea"
     ],
     "qs:name":"Tabwakea Village",
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":890454363,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938156,
     "wof:name":"Tabwakea Village",
     "wof:parent_id":85681277,
     "wof:placetype":"locality",

--- a/data/890/455/235/890455235.geojson
+++ b/data/890/455/235/890455235.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0643\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0438"
     ],
@@ -32,6 +35,9 @@
         "\u039c\u03b1\u03c1\u03b1\u03ba\u03ad\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Marakei"
+    ],
+    "name:est_x_preferred":[
         "Marakei"
     ],
     "name:fas_x_preferred":[
@@ -70,6 +76,9 @@
     "name:nld_x_preferred":[
         "Marakei"
     ],
+    "name:pol_x_preferred":[
+        "Marakei"
+    ],
     "name:por_x_preferred":[
         "Marakei"
     ],
@@ -84,6 +93,9 @@
     ],
     "name:tur_x_preferred":[
         "Marakei"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0440\u0430\u043a\u0435\u0457"
     ],
     "name:zho_x_preferred":[
         "\u99ac\u62c9\u51f1\u74b0\u7901"
@@ -115,7 +127,7 @@
         }
     ],
     "wof:id":890455235,
-    "wof:lastmodified":1566727658,
+    "wof:lastmodified":1690938155,
     "wof:name":"Tekuanga Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/455/237/890455237.geojson
+++ b/data/890/455/237/890455237.geojson
@@ -28,6 +28,9 @@
     "name:ces_x_preferred":[
         "Abemama"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0435\u043c\u0430\u043c\u0430"
+    ],
     "name:deu_x_preferred":[
         "Abemama"
     ],
@@ -35,6 +38,9 @@
         "\u0391\u03bc\u03c0\u03b5\u03bc\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Abemama"
+    ],
+    "name:est_x_preferred":[
         "Abemama"
     ],
     "name:fao_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d9\u30de\u30de"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30d9\u30de\u30de\u74b0\u7901"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10d4\u10db\u10d0\u10db\u10d0"
@@ -135,7 +144,7 @@
         }
     ],
     "wof:id":890455237,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938156,
     "wof:name":"Tekatirirake Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/455/241/890455241.geojson
+++ b/data/890/455/241/890455241.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0643\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0438"
     ],
@@ -32,6 +35,9 @@
         "\u039c\u03b1\u03c1\u03b1\u03ba\u03ad\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Marakei"
+    ],
+    "name:est_x_preferred":[
         "Marakei"
     ],
     "name:fas_x_preferred":[
@@ -70,6 +76,9 @@
     "name:nld_x_preferred":[
         "Marakei"
     ],
+    "name:pol_x_preferred":[
+        "Marakei"
+    ],
     "name:por_x_preferred":[
         "Marakei"
     ],
@@ -84,6 +93,9 @@
     ],
     "name:tur_x_preferred":[
         "Marakei"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0440\u0430\u043a\u0435\u0457"
     ],
     "name:zho_x_preferred":[
         "\u99ac\u62c9\u51f1\u74b0\u7901"
@@ -115,7 +127,7 @@
         }
     ],
     "wof:id":890455241,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938155,
     "wof:name":"Tekarakan Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/455/409/890455409.geojson
+++ b/data/890/455/409/890455409.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0643\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0438"
     ],
@@ -32,6 +35,9 @@
         "\u039c\u03b1\u03c1\u03b1\u03ba\u03ad\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Marakei"
+    ],
+    "name:est_x_preferred":[
         "Marakei"
     ],
     "name:fas_x_preferred":[
@@ -70,6 +76,9 @@
     "name:nld_x_preferred":[
         "Marakei"
     ],
+    "name:pol_x_preferred":[
+        "Marakei"
+    ],
     "name:por_x_preferred":[
         "Marakei"
     ],
@@ -84,6 +93,9 @@
     ],
     "name:tur_x_preferred":[
         "Marakei"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0440\u0430\u043a\u0435\u0457"
     ],
     "name:zho_x_preferred":[
         "\u99ac\u62c9\u51f1\u74b0\u7901"
@@ -115,7 +127,7 @@
         }
     ],
     "wof:id":890455409,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938155,
     "wof:name":"Rawannawi Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/455/481/890455481.geojson
+++ b/data/890/455/481/890455481.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0631\u0627\u064a\u0646\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0422\u044d\u0440\u0430\u0439\u043d\u0430"
     ],
@@ -38,6 +41,9 @@
         "Teraina"
     ],
     "name:epo_x_preferred":[
+        "Teraina"
+    ],
+    "name:est_x_preferred":[
         "Teraina"
     ],
     "name:fas_x_preferred":[
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":890455481,
-    "wof:lastmodified":1566727659,
+    "wof:lastmodified":1690938156,
     "wof:name":"Matanibike Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.