### PR TITLE
ki concordances, placetype local, and more

### DIFF
--- a/data/856/327/09/85632709.geojson
+++ b/data/856/327/09/85632709.geojson
@@ -1027,6 +1027,7 @@
         "hasc:id":"KI",
         "icao:code":"T3",
         "ioc:id":"KIR",
+        "iso:code":"KI",
         "itu:id":"KIR",
         "m49:code":"296",
         "marc:id":"gb",
@@ -1039,6 +1040,7 @@
         "wk:page":"Kiribati",
         "wmo:id":"KB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85681277
     ],
@@ -1064,7 +1066,7 @@
         "eng",
         "gil"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Kiribati",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/812/77/85681277.geojson
+++ b/data/856/812/77/85681277.geojson
@@ -26,7 +26,7 @@
     "mps:latitude":1.820437,
     "mps:longitude":-157.384577,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":18.0,
     "mz:min_zoom":18.0,
     "name:ace_x_preferred":[
@@ -651,8 +651,10 @@
         "gn:id":0,
         "gp:id":23424867,
         "hasc:id":"KI",
+        "iso:code_pseudo":"KI",
         "qs_pg:id":1289462
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         85632709
     ],
@@ -674,7 +676,7 @@
         "eng",
         "gil"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Kiribati",
     "wof:parent_id":85632709,
     "wof:placetype":"region",

--- a/data/856/812/81/85681281.geojson
+++ b/data/856/812/81/85681281.geojson
@@ -19,7 +19,7 @@
     "mps:latitude":0.360009,
     "mps:longitude":173.942139,
     "mz:hierarchy_label":0,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:is_funky":1,
     "mz:max_zoom":18.0,
     "mz:min_zoom":18.0,
@@ -47,7 +47,10 @@
         85632709
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"KI"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"KI",
     "wof:geomhash":"cab87d5b7808b1e2b92ee19af23d5315",
     "wof:hierarchy":[
@@ -66,7 +69,7 @@
         "eng",
         "gil"
     ],
-    "wof:lastmodified":1694493127,
+    "wof:lastmodified":1695884284,
     "wof:name":"Minor islands of Kiribati",
     "wof:parent_id":85632709,
     "wof:placetype":"region",

--- a/data/890/418/571/890418571.geojson
+++ b/data/890/418/571/890418571.geojson
@@ -161,7 +161,7 @@
         }
     ],
     "wof:id":890418571,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Butaritari",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/575/890418575.geojson
+++ b/data/890/418/575/890418575.geojson
@@ -175,7 +175,7 @@
         }
     ],
     "wof:id":890418575,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Kanton",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/577/890418577.geojson
+++ b/data/890/418/577/890418577.geojson
@@ -245,7 +245,7 @@
         }
     ],
     "wof:id":890418577,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Kiritimati",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/579/890418579.geojson
+++ b/data/890/418/579/890418579.geojson
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":890418579,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886196,
     "wof:name":"Kuria",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/581/890418581.geojson
+++ b/data/890/418/581/890418581.geojson
@@ -128,7 +128,7 @@
         }
     ],
     "wof:id":890418581,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Maiana",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/418/583/890418583.geojson
+++ b/data/890/418/583/890418583.geojson
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":890418583,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Makin",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/251/890424251.geojson
+++ b/data/890/424/251/890424251.geojson
@@ -140,7 +140,7 @@
         }
     ],
     "wof:id":890424251,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Abaiang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/253/890424253.geojson
+++ b/data/890/424/253/890424253.geojson
@@ -146,7 +146,7 @@
         }
     ],
     "wof:id":890424253,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Abemama",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/255/890424255.geojson
+++ b/data/890/424/255/890424255.geojson
@@ -155,7 +155,7 @@
         }
     ],
     "wof:id":890424255,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Aranuka",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/257/890424257.geojson
+++ b/data/890/424/257/890424257.geojson
@@ -156,7 +156,7 @@
         }
     ],
     "wof:id":890424257,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Arorae",
     "wof:parent_id":85681277,
     "wof:placetype":"county",

--- a/data/890/424/259/890424259.geojson
+++ b/data/890/424/259/890424259.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":890424259,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Banaba",
     "wof:parent_id":85681277,
     "wof:placetype":"county",

--- a/data/890/424/263/890424263.geojson
+++ b/data/890/424/263/890424263.geojson
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":890424263,
-    "wof:lastmodified":1694497770,
+    "wof:lastmodified":1695887123,
     "wof:name":"Beru",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/003/890429003.geojson
+++ b/data/890/429/003/890429003.geojson
@@ -131,7 +131,7 @@
         }
     ],
     "wof:id":890429003,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Marakei",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/087/890429087.geojson
+++ b/data/890/429/087/890429087.geojson
@@ -122,7 +122,7 @@
         }
     ],
     "wof:id":890429087,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Nikunau",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/089/890429089.geojson
+++ b/data/890/429/089/890429089.geojson
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":890429089,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Onotoa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/643/890445643.geojson
+++ b/data/890/445/643/890445643.geojson
@@ -164,7 +164,7 @@
         }
     ],
     "wof:id":890445643,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Tabuaeran",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/647/890445647.geojson
+++ b/data/890/445/647/890445647.geojson
@@ -258,7 +258,7 @@
         }
     ],
     "wof:id":890445647,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Tamana",
     "wof:parent_id":85681277,
     "wof:placetype":"county",

--- a/data/890/445/649/890445649.geojson
+++ b/data/890/445/649/890445649.geojson
@@ -272,7 +272,7 @@
         }
     ],
     "wof:id":890445649,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Tarawa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/651/890445651.geojson
+++ b/data/890/445/651/890445651.geojson
@@ -137,7 +137,7 @@
         }
     ],
     "wof:id":890445651,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"Teraina",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.